### PR TITLE
mcrouter - Include Network Utils

### DIFF
--- a/mcrouter/scripts/clean_ubuntu_18.04.sh
+++ b/mcrouter/scripts/clean_ubuntu_18.04.sh
@@ -22,6 +22,10 @@ apt-get autoremove --purge -y
 apt-get autoclean -y
 apt-get clean -y
 
+# OPTIONAL: Installs basic network tools to aid in debugging
+apt-get --no-install-recommends -y install telnet traceroute ngrep net-tools \
+    iftop mtr-tiny netcat iputils-ping
+
 # IMPORTANT: Needed as folly is compiled against a specific version
 # of zstd, which isn't available from Ubuntu upstream.
 # See https://github.com/facebook/mcrouter/blob/


### PR DESCRIPTION
Installs basic network utilities (ping, netcat,
traceroute, netstat, etc.) necessary for common
debugging situations.